### PR TITLE
shells hidden from players

### DIFF
--- a/buckshot_roulette/ai.py
+++ b/buckshot_roulette/ai.py
@@ -32,6 +32,7 @@ class Dealer(AbstractEngine):
     def __init__(self, playing_as: Literal[0, 1]):   
         self.me = playing_as     
         self.known_shells: list[bool] = None
+        self.last_shell = None
     
     def shell_at(self, idx, board: BuckshotRoulette) -> Literal[True, False, None]:
         if self.known_shells[idx] != None:
@@ -61,7 +62,9 @@ class Dealer(AbstractEngine):
     
     def choice(self, board: BuckshotRoulette):
         if self.known_shells == None:
-            self.known_shells = [None] * board.total
+            self.known_shells = [None] * board.total     
+            # The dealer always knows the last shell
+            self.known_shells[-1] = self.last_shell    
             if board.total == 1:
                 self.known_shells[0] = board.live > 0
         while len(self.known_shells) > board.total:

--- a/buckshot_roulette/ai.py
+++ b/buckshot_roulette/ai.py
@@ -27,6 +27,14 @@ class AbstractEngine(abc.ABC):
             result (Any): The output of board.make_move
         """
         pass
+    
+    @abc.abstractsmethod
+    def on_reload(self, board:BuckshotRoulette):
+        """Any internal steps to perform on a reload (like resetting knowledge)
+        
+        Args:
+            board (BuckshotRoulette): The new game state
+        """
 
 class Dealer(AbstractEngine):
     def __init__(self, playing_as: Literal[0, 1]):   
@@ -135,6 +143,10 @@ class Dealer(AbstractEngine):
                 self.known_shells[0] = move_result
             case 'burner_phone':
                 self.known_shells[move_result[0]] = move_result[1]
+    
+    def on_reload(self, board: BuckshotRoulette):
+        self.last_shell = None
+        self.known_shells = None
             
             
         
@@ -146,6 +158,9 @@ class Random(AbstractEngine):
         return random.choice(board.moves())
 
     def post(self, last_move, res):
+        pass
+    
+    def on_reload(self, board: BuckshotRoulette):
         pass
 
 class Human(AbstractEngine):
@@ -231,3 +246,6 @@ active items:
                 self.known_shells[0] = move_result
             case 'burner_phone':
                 self.known_shells[move_result[0]] = move_result[1]
+    
+    def on_reload(self, board: BuckshotRoulette):
+        self.known_shells = None

--- a/buckshot_roulette/game.py
+++ b/buckshot_roulette/game.py
@@ -1,7 +1,7 @@
 import random
 from dataclasses import dataclass, astuple
 import copy
-
+from buckshot_roulette.ai import Dealer
 @dataclass(init=True)
 class Items():
     handcuffs: int = 0
@@ -70,6 +70,8 @@ class BuckshotGame:
                 shotgun = ([True] * board.live) + ([False] * (board.total - board.live))
                 random.shuffle(shotgun)
             player = self.engine0 if board.current_turn == 0 else self.engine1
+            if isinstance(player, Dealer):
+                player.last_shell = shotgun[-1]
             if itemsused:
                 print("\n\n------------------------------------------------------------")
                 print(f"player {board.current_turn}")
@@ -85,7 +87,7 @@ class BuckshotGame:
                 player.post(mov, res)
         
         if celebrate:
-            print("player",board.winner(),"wins!")
+            print("player", board.winner(), "wins!")
         return board.winner()
     
 class BuckshotRoulette:

--- a/buckshot_roulette/game.py
+++ b/buckshot_roulette/game.py
@@ -67,6 +67,8 @@ class BuckshotGame:
         random.shuffle(shotgun)
         while board.winner() == None:
             if len(shotgun) == 0:
+                self.engine0.on_reload(board)
+                self.engine1.on_reload(board)
                 shotgun = ([True] * board.live) + ([False] * (board.total - board.live))
                 random.shuffle(shotgun)
             player = self.engine0 if board.current_turn == 0 else self.engine1

--- a/buckshot_roulette/game.py
+++ b/buckshot_roulette/game.py
@@ -56,21 +56,44 @@ class ItemIterable():
         else:
             raise StopIteration
 
+class BuckshotGame:
+    def __init__(self, engine0, engine1):
+        self.engine0 = engine0
+        self.engine1 = engine1
+
+    def play(self, starter = 0, charges=4, celebrate = True):
+        board = BuckshotRoulette(starter, charge_count=charges)
+        shotgun = ([True] * board.live) + ([False] * (board.total - board.live))
+        random.shuffle(shotgun)
+        while board.winner() == None:
+            if len(shotgun) == 0:
+                shotgun = ([True] * board.live) + ([False] * (board.total - board.live))
+                random.shuffle(shotgun)
+            player = self.engine0 if board.current_turn == 0 else self.engine1
+            move = player.choice(board)
+            res, shotgun = board.make_move(move, shotgun)
+            player.post(move, res)
+        
+        if celebrate:
+            print("player",board.winner(),"wins!")
+        return board.winner()
+    
 class BuckshotRoulette:
     POSSIBLE_ITEMS = ['handcuffs', 'magnifying_glass', 'beer', 'cigarettes', 'saw', 'inverter', 'burner_phone', 'meds', 'adrenaline']
     ITEM_CAPS = Items(handcuffs=1, magnifying_glass=3, beer=2, cigarettes=1, saw=3, inverter=8, burner_phone=1, meds=1, adrenaline=2)
-    def __init__(self, charge_count = None, total_rounds = None, live_rounds = None):
+    def __init__(self, starter = 0, charge_count = None, total_rounds = None, live_rounds = None):
         self.max_charges = charge_count if charge_count else random.randint(2, 4)
         self.charges = [self.max_charges, self.max_charges]
-        self.current_turn = 0
+        self.starter = starter
+        self.current_turn = starter
         
-        total = total_rounds if total_rounds else random.randint(2, 8)
-        live = total // 2 if live_rounds == None else live_rounds
-        if live > total:
+        self.total = total_rounds if total_rounds else random.randint(2, 8)
+        self.live = self.total // 2 if live_rounds == None else live_rounds
+        if self.live > self.total:
             raise ValueError("Live Rounds must be less than Total Rounds")
         
-        self._shotgun = ([True] * live) + ([False * (total - live)])
-        random.shuffle(self._shotgun)
+        #self._shotgun = ([True] * live) + ([False * (total - live)])
+        #random.shuffle(self._shotgun)
         
         self.items: list[Items] = [
             Items(),
@@ -82,13 +105,13 @@ class BuckshotRoulette:
         self._skip_next = False
         
         self.chamber_public = None
-        self.give_items(random.randint(2, 5))       
+        self.give_items(random.randint(2, 5))
 
     def new_rounds(self, drop_items = True):
-        total = random.randint(2, 8)
-        live = total // 2
-        self._shotgun = ([True] * live) + ([False] * (total - live))
-        random.shuffle(self._shotgun)
+        self.total = random.randint(2, 8)
+        self.live = self.total // 2
+        #self._shotgun = ([True] * self.live) + ([False] * (self.total - self.live))
+        #random.shuffle(self._shotgun)
         if drop_items:
             self.give_items(random.randint(2, 5))
     
@@ -108,9 +131,9 @@ class BuckshotRoulette:
             for item in items:
                 player[item] += 1
     
-    def shotgun_info(self):
-        live = sum([1 if x else 0 for x in self._shotgun])
-        return live, len(self._shotgun)
+#    def shotgun_info(self):
+#        live = sum([1 if x else 0 for x in self._shotgun])
+#        return live, len(self._shotgun)
     
     def winner(self) -> int | None:
         # Ties are impossible so we don't account for that
@@ -121,10 +144,13 @@ class BuckshotRoulette:
         else:
             return None        
         
-    def fire(self, at_opponent=True) -> None:
+    def fire(self, shotgun, at_opponent=True) -> None:
         target = (self.current_turn + at_opponent) % 2
-        is_hit = self._shotgun[0]
-        self._shotgun = self._shotgun[1:]
+        is_hit = shotgun[0]
+        self.total -= 1
+        if is_hit:
+            self.live -= 1
+        shotgun = shotgun[1:]
         self.chamber_public = None
         
         def switch():
@@ -147,12 +173,12 @@ class BuckshotRoulette:
                 damage = 2
             self.charges[target] -= damage
             switch()
-            return damage
+            return damage, shotgun
         elif at_opponent: # Missed against opponent
             switch()
-            return 0
+            return 0, shotgun
         else: # Shot at self and missed
-            return 0
+            return 0, shotgun
     
     def legal_items(self) -> list[str]:
         """All items that could be used in the current board state, regardless of whether the player currently has them
@@ -182,7 +208,7 @@ class BuckshotRoulette:
             return self.moves()            
         return moves
 
-    def make_move(self, move, load_new = True):
+    def make_move(self, move, shotgun, load_new = True):
         out_val = None
         if self._active_items.adrenaline > 0:
             items = self.items[self.opponent()]
@@ -191,25 +217,27 @@ class BuckshotRoulette:
             items = self.items[self.current_turn]
         match move:
             case 'op':
-                out_val = self.fire(at_opponent=True)
+                out_val, shotgun = self.fire(shotgun, at_opponent=True)
             case 'self':
-                out_val = -self.fire(at_opponent=False)
+                out_val, shotgun = self.fire(shotgun, at_opponent=False)
+                out_val = -out_val
             case 'handcuffs':
                 items.handcuffs -= 1
                 self._active_items.handcuffs += 1
                 self._skip_next = True
             case 'magnifying_glass':
                 items.magnifying_glass -= 1
-                out_val = self._shotgun[0]
-                self.chamber_public = self._shotgun[0]
+                out_val = shotgun[0]
+                self.chamber_public = shotgun[0]
             case 'beer':
                 items.beer -= 1
-                if len(self._shotgun) > 1:
-                    val = self._shotgun[0]
-                    self._shotgun = self._shotgun[1:]
+                self.total -= 1
+                if len(shotgun) > 1:
+                    val = shotgun[0]
+                    shotgun = shotgun[1:]
                     out_val = val
                 else:
-                    self._shotgun = []
+                    shotgun = []
             case 'cigarettes':
                 items.cigarettes -= 1
                 self.charges[self.current_turn] = min(self.charges[self.current_turn]+1, self.max_charges)
@@ -218,12 +246,12 @@ class BuckshotRoulette:
                 self._active_items.saw += 1
             case 'inverter':
                 items.inverter -= 1
-                self._shotgun[0] = not self._shotgun[0]
+                shotgun[0] = not shotgun[0]
             case 'burner_phone':
                 items.burner_phone -= 1
-                if len(self._shotgun) > 1:
-                    idx = random.randint(1, len(self._shotgun)-1)
-                    out_val = (idx, self._shotgun[idx])
+                if len(shotgun) > 1:
+                    idx = random.randint(1, len(shotgun)-1)
+                    out_val = (idx, shotgun[idx])
             case 'meds':
                 items.meds -= 1
                 if random.random() > 0.5:
@@ -235,15 +263,12 @@ class BuckshotRoulette:
                 self._active_items.adrenaline += 1
                     
         
-        if load_new and len(self._shotgun) == 0:
-            self.current_turn = 0
+        if load_new and len(shotgun) == 0:
+            self.current_turn = self.starter
             self.new_rounds()
-            return out_val
+            return out_val, shotgun
         
-        return out_val
-    
-    def live_round(self):
-        return self._shotgun[0]
+        return out_val, shotgun
     
     def switch_turn(self):
         #self._active_items = {'handcuffs': 0, 'magnifying_glass': 0, 'beer': 0, 'cigarettes': 0, 'saw': 0}

--- a/buckshot_roulette/game.py
+++ b/buckshot_roulette/game.py
@@ -61,7 +61,7 @@ class BuckshotGame:
         self.engine0 = engine0
         self.engine1 = engine1
 
-    def play(self, starter = 0, charges=4, celebrate = True):
+    def play(self, starter = 0, charges=4, celebrate = True, itemsused = True):
         board = BuckshotRoulette(starter, charge_count=charges)
         shotgun = ([True] * board.live) + ([False] * (board.total - board.live))
         random.shuffle(shotgun)
@@ -70,8 +70,13 @@ class BuckshotGame:
                 shotgun = ([True] * board.live) + ([False] * (board.total - board.live))
                 random.shuffle(shotgun)
             player = self.engine0 if board.current_turn == 0 else self.engine1
+            if itemsused:
+                print("\n\n------------------------------------------------------------")
+                print(f"player {board.current_turn}")
             move = player.choice(board)
             res, shotgun = board.make_move(move, shotgun)
+            if itemsused:
+                print(f"{move} : {res}")
             player.post(move, res)
         
         if celebrate:
@@ -147,9 +152,6 @@ class BuckshotRoulette:
     def fire(self, shotgun, at_opponent=True) -> None:
         target = (self.current_turn + at_opponent) % 2
         is_hit = shotgun[0]
-        self.total -= 1
-        if is_hit:
-            self.live -= 1
         shotgun = shotgun[1:]
         self.chamber_public = None
         
@@ -231,7 +233,6 @@ class BuckshotRoulette:
                 self.chamber_public = shotgun[0]
             case 'beer':
                 items.beer -= 1
-                self.total -= 1
                 if len(shotgun) > 1:
                     val = shotgun[0]
                     shotgun = shotgun[1:]
@@ -268,6 +269,9 @@ class BuckshotRoulette:
             self.new_rounds()
             return out_val, shotgun
         
+        if move != 'inverter':
+            self.total = len(shotgun)
+            self.live = sum(shotgun)
         return out_val, shotgun
     
     def switch_turn(self):

--- a/buckshot_roulette/game.py
+++ b/buckshot_roulette/game.py
@@ -74,10 +74,15 @@ class BuckshotGame:
                 print("\n\n------------------------------------------------------------")
                 print(f"player {board.current_turn}")
             move = player.choice(board)
-            res, shotgun = board.make_move(move, shotgun)
-            if itemsused:
-                print(f"{move} : {res}")
-            player.post(move, res)
+            if type(move) == str:
+                move = move.split(" ")
+            for mov in move:
+                res, shotgun = board.make_move(mov, shotgun)
+                if res == "INVALID_MOVE":
+                    break
+                if itemsused:
+                    print(f"{move} : {res}")
+                player.post(mov, res)
         
         if celebrate:
             print("player",board.winner(),"wins!")
@@ -262,6 +267,8 @@ class BuckshotRoulette:
             case 'adrenaline':
                 items.adrenaline -= 1
                 self._active_items.adrenaline += 1
+            case _:
+                out_val = "INVALID_MOVE"
                     
         
         if load_new and len(shotgun) == 0:

--- a/test.py
+++ b/test.py
@@ -1,12 +1,23 @@
 from buckshot_roulette.game import BuckshotRoulette, BuckshotGame
-from buckshot_roulette.ai import Dealer, Random
+from buckshot_roulette.ai import *
 
-n = 10000
 
-engine0 = Random(0)
-engine1 = Dealer(1)
-game = BuckshotGame(engine0, engine1)
-p1_wins = 0
-for i in range(1,n+1):
-    p1_wins += game.play(charges = 4, celebrate= False)
-print(f"the dealer has a {100*p1_wins / n:.2f}% win rate")
+
+if True:
+    # ai vs ai
+    engine0 = Random(0)
+    engine1 = Dealer(1)
+    game = BuckshotGame(engine0, engine1)
+    p1_wins = 0
+    n = 10000
+    for i in range(1,n+1):
+        p1_wins += game.play(charges = 4, celebrate= False, itemsused= False)
+    print(f"the dealer has a {100*p1_wins / n:.2f}% win rate")
+
+if False:
+    # human vs dealer
+    # ai vs ai
+    engine0 = Human(0, knowledge=True)
+    engine1 = Dealer(1)
+    game = BuckshotGame(engine0, engine1)
+    p1_wins += game.play(charges = 4, celebrate= True, itemsused= True)

--- a/test.py
+++ b/test.py
@@ -1,17 +1,12 @@
-from buckshot_roulette.game import BuckshotRoulette
+from buckshot_roulette.game import BuckshotRoulette, BuckshotGame
 from buckshot_roulette.ai import Dealer, Random
 
+n = 10000
+
+engine0 = Random(0)
+engine1 = Dealer(1)
+game = BuckshotGame(engine0, engine1)
 p1_wins = 0
-for _ in range(1, 100000):
-    board = BuckshotRoulette(4)
-    engine1 = Random(0)
-    engine2 = Dealer(1)
-    while board.winner() == None:
-        player = engine1 if board.current_turn == 0 else engine2
-        move = player.choice(board)
-        res = board.make_move(move)
-        player.post(move, res)
-    if board.winner() == 0:
-        p1_wins += 1
-    print(f"[{_}] Player {board.winner()+1} Wins! {100*p1_wins / _:.2f}%")
-    #print(board.items)
+for i in range(1,n+1):
+    p1_wins += game.play(charges = 4, celebrate= False)
+print(f"the dealer has a {100*p1_wins / n:.2f}% win rate")


### PR DESCRIPTION
BuckshotRoulette:
    no longer has self._shotgun
    has self.live and self.total now
        will not change when inverter used, even if top is known
        shotgun_info() and live_round() no longer necessary
    has self.starter on init to set which player goes first (default 0)
    fire() and make_move() both take the shotgun as an argument and return a modified shotgun
        note: they do not save any information about it

Dealer:
    no longer has access to the shotgun, so stores knowledge internally
    known_shells works differently
        None: shell is not known at index
        True: shell is known to be live at index
        False: shell is known to be blank at index
    shell_at functions the same

BuckshotGame:
    controls game flow
    stores no information other than the shotgun
    passes shotgun to BuckshotRoulette for modification
    returns position of winner

fixed a typo in the shotgun creation causing there to always be one blank
somehow fixed a bug that was causing the dealer to play really poorly for some reason